### PR TITLE
Update publications.bib

### DIFF
--- a/publications.bib
+++ b/publications.bib
@@ -105,4 +105,20 @@ abstract="Automated software debloating of program source or binary code has tre
   year={2023},
   publisher={Springer}
 }
-
+@inproceedings{10.1145/3578360.3580260,
+  author = {Lim, HeuiChan and Debray, Saumya},
+  title = {Automatically Localizing Dynamic Code Generation Bugs in JIT Compiler Back-End},
+  year = {2023},
+  isbn = {9798400700880},
+  publisher = {Association for Computing Machinery},
+  address = {New York, NY, USA},
+  url = {https://doi.org/10.1145/3578360.3580260},
+  doi = {10.1145/3578360.3580260},
+  abstract = {Just-in-Time (JIT) compilers are ubiquitous in modern computing systems and are used in a wide variety of software. Dynamic code generation bugs, where the JIT compiler silently emits incorrect code, can result in exploitable vulnerabilities. They, therefore, pose serious security concerns and make quick mitigation essential. However, due to the size and complexity of JIT compilers, quickly locating and fixing bugs is often challenging. In addition, the unique characteristics of JIT compilers make existing bug localization approaches inapplicable. Therefore, this paper proposes a new approach to automatic bug localization, explicitly targeting the JIT compiler back-end. The approach is based on explicitly modeling architecture-independent back-end representation and architecture-specific code-generation. Experiments using a prototype implementation on a widely used JIT compiler (Turbofan) indicate that it can successfully localize dynamic code generation bugs in the back-end with high accuracy.},
+  booktitle = {Proceedings of the 32nd ACM SIGPLAN International Conference on Compiler Construction},
+  pages = {145–155},
+  numpages = {11},
+  keywords = {JIT Compiler, Dynamic Program Analysis, Back-End, Automatic Bug Localization, Dynamic Code Generation},
+  location = {Montr\'{e}al, QC, Canada},
+  series = {CC 2023}
+}


### PR DESCRIPTION
Automatically Localizing Dynamic Code Generation Bugs in JIT Compiler Back-End
[CC 2023: Proceedings of the 32nd ACM SIGPLAN International Conference on Compiler Construction](https://dl.acm.org/doi/proceedings/10.1145/3578360)